### PR TITLE
Update PHP version constraints to 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This is an unofficial PHP library for generating ZATCA Fatoora e-invoices (simpl
 
 ## 📌 Requirements  
 
-### ✅ PHP Version  
-- **PHP 8.1 or higher**
+### ✅ PHP Version
+- **PHP 7.4 or higher**
 
 
 ## 🛠 Installation  

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.1",
+        "php": "^7.4",
         "ext-fileinfo": "*",
         "ext-mbstring": "*",
         "ext-dom": "*",
@@ -37,7 +37,7 @@
         "ext-openssl": "*",
         "ext-hash": "*",
         "sabre/xml": "^4.0",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "phpseclib/phpseclib": "^3.0",
         "sevaske/zatca-api": "^1.0"
@@ -45,8 +45,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "guzzlehttp/guzzle": "^7.9",
-        "phpstan/phpstan": "^2.1",
-        "laravel/pint": "^1.20"
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- relax PHP constraint to allow 7.4
- depend on `psr/http-message` 1.x and `phpstan` 1.x
- drop Laravel Pint which requires PHP 8.1
- update README to mention PHP 7.4 minimum

## Testing
- `composer update --no-interaction --ignore-platform-reqs` *(fails: sevaske/zatca-api v1.0 requires psr/http-message ^2.0)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688257ab523083318dc657de1c944bdc