### PR TITLE
Remove union type hints from setters

### DIFF
--- a/src/AllowanceCharge.php
+++ b/src/AllowanceCharge.php
@@ -192,8 +192,10 @@ class AllowanceCharge implements XmlSerializable
 
     /**
      * Set the tax category.
+     *
+     * @param TaxCategory|array|null $taxCategory
      */
-    public function setTaxCategory(TaxCategory|array|null $taxCategory): self
+    public function setTaxCategory($taxCategory): self
     {
         if ($taxCategory instanceof TaxCategory) {
             $this->taxCategory = [$taxCategory];

--- a/src/Delivery.php
+++ b/src/Delivery.php
@@ -29,9 +29,10 @@ class Delivery implements XmlSerializable
      *
      * Accepts a DateTime instance or a date string (which will be converted to DateTime).
      *
+     * @param DateTime|string|null $actualDeliveryDate
      * @throws InvalidArgumentException if the date string is invalid.
      */
-    public function setActualDeliveryDate(DateTime|string|null $actualDeliveryDate): self
+    public function setActualDeliveryDate($actualDeliveryDate): self
     {
         if (is_string($actualDeliveryDate)) {
             try {
@@ -58,9 +59,10 @@ class Delivery implements XmlSerializable
      *
      * Accepts a DateTime instance or a date string (which will be converted to DateTime).
      *
+     * @param DateTime|string|null $latestDeliveryDate
      * @throws InvalidArgumentException if the date string is invalid.
      */
-    public function setLatestDeliveryDate(DateTime|string|null $latestDeliveryDate): self
+    public function setLatestDeliveryDate($latestDeliveryDate): self
     {
         if (is_string($latestDeliveryDate)) {
             try {

--- a/src/Item.php
+++ b/src/Item.php
@@ -145,8 +145,10 @@ class Item implements XmlSerializable
 
     /**
      * Set the classified tax category.
+     *
+     * @param ClassifiedTaxCategory|array|null $classifiedTaxCategory
      */
-    public function setClassifiedTaxCategory(ClassifiedTaxCategory|array|null $classifiedTaxCategory): self
+    public function setClassifiedTaxCategory($classifiedTaxCategory): self
     {
         if ($classifiedTaxCategory instanceof ClassifiedTaxCategory) {
             $this->classifiedTaxCategory = [$classifiedTaxCategory];

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -87,7 +87,7 @@ class InvoiceMapper
      *
      * @throws InvalidArgumentException If invalid JSON data is provided.
      */
-    public function mapToInvoice(array|string $data): Invoice
+    public function mapToInvoice($data): Invoice
     {
         // If data is a JSON string, convert it to an array.
         if (is_string($data)) {


### PR DESCRIPTION
## Summary
- drop union type hints from Delivery, AllowanceCharge, Item and InvoiceMapper
- document union parameter types in phpdoc comments

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688257ae240483319dcb36d12811765f