### PR TITLE
Fix return types

### DIFF
--- a/src/AdditionalDocumentReference.php
+++ b/src/AdditionalDocumentReference.php
@@ -28,7 +28,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
         return $this->id;
     }
 
-    public function setId(?string $id): static
+    public function setId(?string $id): self
     {
         $this->id = $id;
 
@@ -40,7 +40,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
         return $this->UUID;
     }
 
-    public function setUUID(?string $UUID): static
+    public function setUUID(?string $UUID): self
     {
         $this->UUID = $UUID;
 
@@ -52,7 +52,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
         return $this->documentType;
     }
 
-    public function setDocumentType(?string $documentType): static
+    public function setDocumentType(?string $documentType): self
     {
         $this->documentType = $documentType;
 
@@ -64,7 +64,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
         return $this->documentTypeCode;
     }
 
-    public function setDocumentTypeCode(?int $documentTypeCode): static
+    public function setDocumentTypeCode(?int $documentTypeCode): self
     {
         $this->documentTypeCode = $documentTypeCode;
 
@@ -76,7 +76,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
         return $this->documentDescription;
     }
 
-    public function setDocumentDescription(?string $documentDescription): static
+    public function setDocumentDescription(?string $documentDescription): self
     {
         $this->documentDescription = $documentDescription;
 
@@ -88,7 +88,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
         return $this->attachment;
     }
 
-    public function setAttachment(?Attachment $attachment): static
+    public function setAttachment(?Attachment $attachment): self
     {
         $this->attachment = $attachment;
 
@@ -132,7 +132,7 @@ class AdditionalDocumentReference implements XmlDeserializable, XmlSerializable
     /**
      * The xmlDeserialize method is called during xml reading.
      */
-    public static function xmlDeserialize(Reader $reader): static
+    public static function xmlDeserialize(Reader $reader): self
     {
         $keyValues = keyValue($reader);
 

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -41,7 +41,7 @@ class Attachment implements XmlDeserializable, XmlSerializable
         return $this->filePath;
     }
 
-    public function setFilePath(string $filePath): static
+    public function setFilePath(string $filePath): self
     {
         $this->filePath = $filePath;
 
@@ -53,7 +53,7 @@ class Attachment implements XmlDeserializable, XmlSerializable
         return $this->externalReference;
     }
 
-    public function setExternalReference(string $externalReference): static
+    public function setExternalReference(string $externalReference): self
     {
         $this->externalReference = $externalReference;
 
@@ -68,7 +68,7 @@ class Attachment implements XmlDeserializable, XmlSerializable
     /**
      * @param  string  $base64Content  Base64 encoded base64Content
      */
-    public function setBase64Content(string $base64Content, string $fileName, ?string $mimeType): static
+    public function setBase64Content(string $base64Content, string $fileName, ?string $mimeType): self
     {
         $this->base64Content = $base64Content;
         $this->fileName = $fileName;
@@ -82,7 +82,7 @@ class Attachment implements XmlDeserializable, XmlSerializable
         return $this->fileName;
     }
 
-    public function setFileName(string $fileName): static
+    public function setFileName(string $fileName): self
     {
         $this->fileName = $fileName;
 
@@ -94,7 +94,7 @@ class Attachment implements XmlDeserializable, XmlSerializable
         return $this->mimeType;
     }
 
-    public function setMimeType(?string $mimeType): static
+    public function setMimeType(?string $mimeType): self
     {
         $this->mimeType = $mimeType;
 
@@ -162,7 +162,7 @@ class Attachment implements XmlDeserializable, XmlSerializable
     /**
      * The xmlDeserialize method is called during xml reading.
      */
-    public static function xmlDeserialize(Reader $reader): static
+    public static function xmlDeserialize(Reader $reader): self
     {
         $mixedContent = mixedContent($reader);
         $embeddedDocumentBinaryObject = array_values(array_filter($mixedContent, fn ($element) => $element['name'] === Schema::CBC.'EmbeddedDocumentBinaryObject'))[0] ?? null;


### PR DESCRIPTION
## Summary
- use `self` return type for fluent interfaces

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688257ae8b88833197f29e700b19dfe0