### PR TITLE
Use compat helpers and explicit null checks

### DIFF
--- a/src/Helpers/Compat.php
+++ b/src/Helpers/Compat.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Saleh7\Zatca\Helpers;
+
+class Compat
+{
+    public static function strContains(string $haystack, string $needle): bool
+    {
+        if (function_exists('str_contains')) {
+            return str_contains($haystack, $needle);
+        }
+
+        return mb_strpos($haystack, $needle) !== false;
+    }
+
+    public static function strStartsWith(string $haystack, string $needle): bool
+    {
+        if (function_exists('str_starts_with')) {
+            return str_starts_with($haystack, $needle);
+        }
+
+        return strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Compat helper with string polyfills
- update InvoiceExtension to use Compat functions
- replace nullsafe operators with explicit checks

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688257b0ee6c8331b6a9cbf624c43a98