### PR TITLE
Update dependencies for PHP 7.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ The original namespace `Saleh7\Zatca` has not been changed to maintain compatibi
 If the original author returns and resumes activity, we are open to merging all changes and improvements back into the original repository.
 
 **API Integration:**  
-API-related functionality has been refactored and moved to a separate library for better modularity and maintainability:  
-🔗 [sevaske/zatca-api](https://github.com/sevaske/zatca-api)
+API-related functionality has been refactored and moved to a separate library for better modularity and maintainability.
+If you need API integration, you may install the optional package
+🔗 [sevaske/zatca-api](https://github.com/sevaske/zatca-api) (requires PHP 8.1+)
 
 Original project: [https://github.com/Saleh7/php-zatca-xml](https://github.com/Saleh7/php-zatca-xml)
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.1",
+        "php": "^8.0",
         "ext-fileinfo": "*",
         "ext-mbstring": "*",
         "ext-dom": "*",
@@ -39,14 +39,13 @@
         "sabre/xml": "^4.0",
         "psr/http-message": "^2.0",
         "psr/http-client": "^1.0",
-        "phpseclib/phpseclib": "^3.0",
-        "sevaske/zatca-api": "^1.0"
+        "phpseclib/phpseclib": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "guzzlehttp/guzzle": "^7.9",
         "phpstan/phpstan": "^2.1",
-        "laravel/pint": "^1.20"
+        "friendsofphp/php-cs-fixer": "^3.24"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exceptions/ZatcaException.php
+++ b/src/Exceptions/ZatcaException.php
@@ -10,13 +10,42 @@ use Throwable;
  *
  * Base exception class for ZATCA-related errors.
  */
-class ZatcaException extends \Sevaske\ZatcaApi\Exceptions\ZatcaException
+class ZatcaException extends Exception
 {
+    /**
+     * Additional contextual information for the exception.
+     *
+     * @var array
+     */
+    protected array $context = [];
+
+    /**
+     * Default message when none is provided.
+     */
     protected string $defaultMessage = 'An error occurred';
 
     public function __construct(?string $message = null, array $context = [], int $code = 0, ?Throwable $previous = null)
     {
-        parent::__construct($message ?? $this->getDefaultMessage(), $context, $code, $previous);
+        parent::__construct($message ?? $this->getDefaultMessage(), $code, $previous);
+        $this->context = $context;
+    }
+
+    /**
+     * Merge additional context into the exception.
+     */
+    public function withContext(array $context): self
+    {
+        $this->context = array_merge($this->context, $context);
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the context array.
+     */
+    public function context(): array
+    {
+        return $this->context;
     }
 
     protected function getDefaultMessage(): string


### PR DESCRIPTION
## Summary
- replace `laravel/pint` with `friendsofphp/php-cs-fixer`
- drop `sevaske/zatca-api` requirement
- relax PHP constraint to `^8.0`
- update the API integration docs
- inline exception handling so the API package is optional

## Testing
- `composer validate --no-check-all`
- `composer install --no-interaction`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688257b371c483318d313f09b3651e1a