### PR TITLE
Add PHP 7.4 to CI workflows

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,20 +3,23 @@ name: CI
 on: [push, pull_request]
 
 jobs:
- build-test:
-   runs-on: ubuntu-latest
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [ '7.4', '8.2' ]
 
-   steps:
-     - uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v3
 
-     - name: Set up PHP
-       uses: shivammathur/setup-php@v2
-       with:
-         php-version: '8.2'
-         extensions: mbstring, xml, ctype, json, curl, openssl
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, xml, ctype, json, curl, openssl
 
-     - name: Install Composer dependencies
-       run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
 
-     - name: Run PHPUnit tests
-       run: vendor/bin/phpunit tests
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit tests

--- a/.github/workflows/validate_fatoora.yml
+++ b/.github/workflows/validate_fatoora.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   validate_invoice:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [ '7.4', '8.1' ]
 
     steps:
       - name: 🛠️ Checkout Repository
@@ -13,7 +16,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-            php-version: '8.1'
+            php-version: ${{ matrix.php-version }}
             extensions: mbstring, xml, ctype, json, curl, openssl
 
       - name: Install Composer dependencies


### PR DESCRIPTION
## Summary
- test against PHP 7.4 and PHP 8.x in GitHub Actions
- validate Fatoora against PHP 7.4 and PHP 8.1

## Testing
- `composer install --ignore-platform-req=php`
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68825fc548348331b622f22d83f96992