### PR TITLE
Add PHP 7.4 to CI workflows

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,20 +3,24 @@ name: CI
 on: [push, pull_request]
 
 jobs:
- build-test:
-   runs-on: ubuntu-latest
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [7.4, 8.2]
 
-   steps:
-     - uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v3
 
-     - name: Set up PHP
-       uses: shivammathur/setup-php@v2
-       with:
-         php-version: '8.2'
-         extensions: mbstring, xml, ctype, json, curl, openssl
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, xml, ctype, json, curl, openssl
 
-     - name: Install Composer dependencies
-       run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
 
-     - name: Run PHPUnit tests
-       run: vendor/bin/phpunit tests
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit tests
+

--- a/.github/workflows/validate_fatoora.yml
+++ b/.github/workflows/validate_fatoora.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   validate_invoice:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [7.4, 8.1]
 
     steps:
       - name: 🛠️ Checkout Repository
@@ -13,7 +16,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-            php-version: '8.1'
+            php-version: ${{ matrix.php-version }}
             extensions: mbstring, xml, ctype, json, curl, openssl
 
       - name: Install Composer dependencies
@@ -96,4 +99,5 @@ jobs:
           fatoora -validate -invoice ../../../examples/output/Standard_Invoice_Signed.xml
           fatoora -validate -invoice ../../../examples/output/Standard_Debit_Note_Signed.xml
           fatoora -validate -invoice ../../../examples/output/Standard_Credit_Note_Signed.xml
+
 

--- a/src/Delivery.php
+++ b/src/Delivery.php
@@ -37,7 +37,7 @@ class Delivery implements XmlSerializable
         if (is_string($actualDeliveryDate)) {
             try {
                 $actualDeliveryDate = new DateTime($actualDeliveryDate);
-            } catch (Exception) {
+            } catch (Exception $e) {
                 throw new InvalidArgumentException('Invalid actual delivery date format.');
             }
         }
@@ -67,7 +67,7 @@ class Delivery implements XmlSerializable
         if (is_string($latestDeliveryDate)) {
             try {
                 $latestDeliveryDate = new DateTime($latestDeliveryDate);
-            } catch (Exception) {
+            } catch (Exception $e) {
                 throw new InvalidArgumentException('Invalid latest delivery date format.');
             }
         }

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -357,7 +357,7 @@ class InvoiceMapper
 
         try {
             return new DateTime($dateTimeStr);
-        } catch (Exception) {
+        } catch (Exception $e) {
             return new DateTime;
         }
     }


### PR DESCRIPTION
## Summary
- test against PHP 7.4 and PHP 8.x in GitHub Actions
- validate Fatoora against PHP 7.4 and PHP 8.1
- update catch blocks for PHP 7.4 compatibility

## Testing
- `composer install --ignore-platform-req=php`
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68825fc548348331b622f22d83f96992